### PR TITLE
Tayjus winn spellcasting dc fixes july 2020

### DIFF
--- a/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/paladin-oath-of-the-north-star.xml
+++ b/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/paladin-oath-of-the-north-star.xml
@@ -2,7 +2,7 @@
 <elements>
     <info>
         <name>Oath of the North Star Sacred Oath</name>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="paladin-oath-of-the-north-star.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/paladin-oath-of-the-north-star.xml" />
         </update>
     </info>
@@ -112,7 +112,7 @@
             <p class="indent">At 18th level, the range of this aura increases to 30 feet.</p>
         </description>
         <sheet action="Bonus Action">
-            <description>You emit an aura of starlight (dim light) in a {{aura-of-stardust:radius}}-foot radius. You can activate or supress this as a bonus action. When an invisible creature moves within {{aura-of-stardust:radius}} feet of you for the first time on a turn or starts its turn there, it must succeed a Dexterity saving throw (save DC {{spellcasting:dc}}) or become coated in tiny motes of stardust. While coated in this way, the affected creature can’t benefit from being invisible. These motes of stardust disappear once the affected creature moves out of the range of your aura.</description>
+            <description>You emit an aura of starlight (dim light) in a {{aura-of-stardust:radius}}-foot radius. You can activate or supress this as a bonus action. When an invisible creature moves within {{aura-of-stardust:radius}} feet of you for the first time on a turn or starts its turn there, it must succeed a Dexterity saving throw (save DC {{spellcasting:dc:cha}}) or become coated in tiny motes of stardust. While coated in this way, the affected creature can’t benefit from being invisible. These motes of stardust disappear once the affected creature moves out of the range of your aura.</description>
         </sheet>
         <rules>
             <stat name="aura-of-stardust:radius" value="10" bonus="base" level="7" />

--- a/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/ranger-shooting-star.xml
+++ b/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/ranger-shooting-star.xml
@@ -2,7 +2,7 @@
 <elements>
     <info>
         <name>Shooting Star Ranger Archetype</name>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="ranger-shooting-star.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/ranger-shooting-star.xml" />
         </update>
     </info>
@@ -68,7 +68,7 @@
                 <p>As an action, you can expend a mote and launch it at a point within 120 feet of you. Each creature within 10 feet of that point must make a Dexterity saving throw against your ranger spell save DC. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one. This damage increases to 3d6 at 7th level, 4d6 at 11th level, and 5d6 at 15th level.</p>
             </description>
             <sheet alt="Scattered Sparks" action="Action">
-                <description>You can expend a mote and launch it at a point within 120 feet of you. Each creature within 10 feet of that point must make a Dexterity saving throw (save DC {{spellcasting:dc}}). A creature takes {{scattered-sparks:damage-dice}}d6 fire damage on a failed save, or half as much damage on a successful one.</description>
+                <description>You can expend a mote and launch it at a point within 120 feet of you. Each creature within 10 feet of that point must make a Dexterity saving throw (save DC {{spellcasting:dc:wis}}). A creature takes {{scattered-sparks:damage-dice}}d6 fire damage on a failed save, or half as much damage on a successful one.</description>
             </sheet>
             <rules>
                 <stat name="scattered-sparks:damage-dice" value="2" level="3" />

--- a/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/sorcerer-star-spawn.xml
+++ b/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/sorcerer-star-spawn.xml
@@ -2,7 +2,7 @@
 <elements>
     <info>
         <name>Star Spawn Sorcerous Origin</name>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="sorcerer-star-spawn.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/sorcerer-star-spawn.xml" />
         </update>
     </info>
@@ -47,7 +47,7 @@
             <p class="indent">Additionally, as a reaction to being hit by an attack, you can spend one sorcery point to negate the damage and magically teleport yourself to an unoccupied space within 30 feet of you.</p>
         </description>
         <sheet action="Action">
-            <description>You can spend one sorcery point to force a creature you can see within 30 feet of you to be forcefully warped. The target must make a Wisdom saving throw (save DC {{spellcasting:dc}}). On a failed save, the target, along with any equipment it is wearing or carrying, is magically teleported up to 30 feet to an unoccupied space you can see. A willing creature can choose to fail this save. </description>
+            <description>You can spend one sorcery point to force a creature you can see within 30 feet of you to be forcefully warped. The target must make a Wisdom saving throw (save DC {{spellcasting:dc:cha}}). On a failed save, the target, along with any equipment it is wearing or carrying, is magically teleported up to 30 feet to an unoccupied space you can see. A willing creature can choose to fail this save. </description>
         </sheet>
         <rules>
             <grant type="Archetype Feature" id="ID_AEYANA_ATLAS_ARCHETYPE_FEATURE_STAR_SPAWN_BEND_SPACE_REACTION" level="6" />
@@ -76,7 +76,7 @@
             <p class="indent">If the creature ends its turn in a location where it doesn’t have line of sight to you, it can repeat the saving throw, ending the effect on a success.</p>
         </description>
         <sheet action="Action">
-            <description>You can spend 5 sorcery points to exude an aura of madness to a distance of 60 feet. Each creature within this area must make a Wisdom saving throw (save DC {{spellcasting:dc}}) or go insane. While insane, it can’t take actions, can’t understand what other creatures say, can’t read, and speak only in gibberish. You can choose up to {{charisma:modifier}} creatures to automatically succeed the saving throw. If the creature ends its turn in a location where it doesn’t have line of sight to you, it can repeat the saving throw, ending the effect on a success.</description>
+            <description>You can spend 5 sorcery points to exude an aura of madness to a distance of 60 feet. Each creature within this area must make a Wisdom saving throw (save DC {{spellcasting:dc:cha}}) or go insane. While insane, it can’t take actions, can’t understand what other creatures say, can’t read, and speak only in gibberish. You can choose up to {{charisma:modifier}} creatures to automatically succeed the saving throw. If the creature ends its turn in a location where it doesn’t have line of sight to you, it can repeat the saving throw, ending the effect on a success.</description>
         </sheet>
     </element>
     <element name="Origin Spells" type="Archetype Feature" source="All the Lights in the Sky are Stars" id="ID_AEYANA_ATLAS_ARCHETYPE_FEATURE_STAR_SPAWN_ORIGIN_SPELLS">

--- a/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/warlock-the-nebula.xml
+++ b/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/warlock-the-nebula.xml
@@ -2,7 +2,7 @@
 <elements>
     <info>
         <name>The Nebula Otherworldly Patron</name>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="warlock-the-nebula.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/warlock-the-nebula.xml" />
         </update>
     </info>
@@ -96,7 +96,7 @@
             <p class="indent">Once you use this feature, you can’t use it again until you finish a short or long rest.</p>
         </description>
         <sheet usage="1/Short Rest">
-            <description>Choose a point within 60 feet you can see. A miniature star bursts into existence at the chosen point. Each creature within 30 feet of the star when it first appears must make a Constitution saving throw (save DC {{spellcasting:dc}}). On a failed save, a creature takes 6d10 radiant damage and is blinded for 1 minute. On a successful save, the creature takes half as much damage and isn’t blinded. At the end of each of its turns, the target can repeat the saving throw, ending the effect on a success. The star shines for one minute, and provides bright light in a 30-foot radius and dim light for an additional 30 feet. Creatures within 30 feet of the star have disadvantage on saving throws against your warlock spells.</description>
+            <description>Choose a point within 60 feet you can see. A miniature star bursts into existence at the chosen point. Each creature within 30 feet of the star when it first appears must make a Constitution saving throw (save DC {{spellcasting:dc:cha}}). On a failed save, a creature takes 6d10 radiant damage and is blinded for 1 minute. On a successful save, the creature takes half as much damage and isn’t blinded. At the end of each of its turns, the target can repeat the saving throw, ending the effect on a success. The star shines for one minute, and provides bright light in a 30-foot radius and dim light for an additional 30 feet. Creatures within 30 feet of the star have disadvantage on saving throws against your warlock spells.</description>
         </sheet>
     </element>
 

--- a/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/wizard-school-of-astronomy.xml
+++ b/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/wizard-school-of-astronomy.xml
@@ -2,7 +2,7 @@
 <elements>
     <info>
         <name>School of Astronomy Arcane Tradition</name>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="wizard-school-of-astronomy.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/all-the-lights-in-the-sky-are-stars/wizard-school-of-astronomy.xml" />
         </update>
     </info>
@@ -43,7 +43,7 @@
             <p class="indent">Additionally, you can use your bonus action to cause any number of spell stars within 60 feet of yourself explode. Each creature within 5 feet of a spell star must make on a Dexterity saving throw against your wizard spell save DC or take 2d6 radiant damage. A creature in the area of more than one spell star burst is affected only once.</p>
         </description>
         <sheet>
-            <description>When you cast a spell of 1st level or higher. When you do so, you choose an unoccupied space within range of the spell, and a spell star appears at the point for 1 minute. The spell star provides bright light in a 10-foot radius and dim light for an additional 10 feet. You can have a number of spell stars at once equal to half your wizard level. While you are within 60 feet of a spell star, you can cast spells as though you were in the spell star’s space. Additionally, you can use your bonus action to cause any number of spell stars within 60 feet of yourself explode. Each creature within 5 feet of a spell star must make on a Dexterity saving (save DC {{spellcasting:dc}}) or take 2d6 radiant damage. A creature in the area of more than one spell star burst is affected only once.</description>
+            <description>When you cast a spell of 1st level or higher. When you do so, you choose an unoccupied space within range of the spell, and a spell star appears at the point for 1 minute. The spell star provides bright light in a 10-foot radius and dim light for an additional 10 feet. You can have a number of spell stars at once equal to half your wizard level. While you are within 60 feet of a spell star, you can cast spells as though you were in the spell star’s space. Additionally, you can use your bonus action to cause any number of spell stars within 60 feet of yourself explode. Each creature within 5 feet of a spell star must make on a Dexterity saving (save DC {{spellcasting:dc:int}}) or take 2d6 radiant damage. A creature in the area of more than one spell star burst is affected only once.</description>
         </sheet>
     </element>
     <element name="Realign" type="Archetype Feature" source="All the Lights in the Sky are Stars" id="ID_AEYANA_ATLAS_ARCHETYPE_FEATURE_SCHOOL_OF_ASTRONOMY_REALIGN">
@@ -51,7 +51,7 @@
             <p>At 6th level, you learn to shift your stars as you desire. As a bonus action on your turn, you can move a spell star within 60 feet of you up to 30 feet in any direction. If you ram the spell star into a creature, that creature must make a Dexterity saving throw against your wizard spell save DC. On a failed save, the creature takes 2d6 radiant damage and the spell star disappears.</p>
         </description>
         <sheet action="Bonus Action">
-            <description>You can move a spell star within 60 feet of you up to 30 feet in any direction. If you ram the spell star into a creature, that creature must make a Dexterity (save DC {{spellcasting:dc}}). On a failed save, the creature takes 2d6 radiant damage and the spell star disappears.</description>
+            <description>You can move a spell star within 60 feet of you up to 30 feet in any direction. If you ram the spell star into a creature, that creature must make a Dexterity (save DC {{spellcasting:dc:int}}). On a failed save, the creature takes 2d6 radiant damage and the spell star disappears.</description>
         </sheet>
     </element>
     <element name="Arcane Constellation" type="Archetype Feature" source="All the Lights in the Sky are Stars" id="ID_AEYANA_ATLAS_ARCHETYPE_FEATURE_SCHOOL_OF_ASTRONOMY_ARCANE_CONSTELLATION">

--- a/reddit/reddit-unearthed-arcana/dark-arts-players-companion/cleric-night-domain.xml
+++ b/reddit/reddit-unearthed-arcana/dark-arts-players-companion/cleric-night-domain.xml
@@ -3,7 +3,7 @@
     <info>
         <name>Night Domain Divine Domain</name>
 		<author url="https://drive.google.com/file/d/1Kr3ZKYy3Me0ZFOhOQAmKBZlB9JUauhW5/view">Jonoman3000</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="cleric-night-domain.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/dark-arts-players-companion/cleric-night-domain.xml" />
         </update>
     </info>
@@ -87,7 +87,7 @@
             <p class="indent">As an action, you present your holy symbol and all lights within 30 feet of you, magical or non-magical, are instantly put out. Additionally, each hostile creature within 30 feet of you must make a Constitution saving throw. A creature takes necrotic damage equal to 2d6 + your cleric level on a failed saving throw, and loses any darkvision they have for 1 minute. On a successful save, they take half as much damage and suffer no other effects. A creature can repeat this saving throw at the start of each of its turns, regaining their darkvision on a success.</p>
         </description>
         <sheet action="Action" usage="Channel Divinity" alt="Midnight Gloom">
-            <description>You present your holy symbol and all lights within 30 feet of you, magical or non-magical, are instantly put out. Additionally, each hostile creature within 30 feet of you must make a Constitution saving throw (save DC {{spellcasting:dc}}). A creature takes necrotic damage equal to 2d6 + {{level:cleric}} on a failed saving throw, and loses any darkvision they have for 1 minute. On a successful save, they take half as much damage and suffer no other effects. A creature can repeat this saving throw at the start of each of its turns, regaining their darkvision on a success.</description>
+            <description>You present your holy symbol and all lights within 30 feet of you, magical or non-magical, are instantly put out. Additionally, each hostile creature within 30 feet of you must make a Constitution saving throw (save DC {{spellcasting:dc:wis}}). A creature takes necrotic damage equal to 2d6 + {{level:cleric}} on a failed saving throw, and loses any darkvision they have for 1 minute. On a successful save, they take half as much damage and suffer no other effects. A creature can repeat this saving throw at the start of each of its turns, regaining their darkvision on a success.</description>
         </sheet>
     </element>
     

--- a/reddit/reddit-unearthed-arcana/dark-arts-players-companion/paladin-oath-of-the-grave.xml
+++ b/reddit/reddit-unearthed-arcana/dark-arts-players-companion/paladin-oath-of-the-grave.xml
@@ -3,7 +3,7 @@
     <info>
         <name>Oath of the Grave Sacred Oath</name>
 		<author url="https://drive.google.com/file/d/1Kr3ZKYy3Me0ZFOhOQAmKBZlB9JUauhW5/view">Jonoman3000</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="paladin-oath-of-the-grave.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/dark-arts-players-companion/paladin-oath-of-the-grave.xml" />
         </update>
     </info>
@@ -90,7 +90,7 @@
             <p class="indent">A frozen creature is affected by the petrified condition until the frozen effect ends, at which point the creature is freed and able to act normally.</p>
         </description>
         <sheet alt="Icy Repose" usage="Channel Divinity" action="Action">
-            <description>You present your holy symbol and speak a prayer against undeath. Each undead that can see or hear you within 30 feet of you must make a Wisdom saving throw (save DC {{spellcasting:dc}}). If the creature fails its saving throw, it is frozen for 1 minute or until it takes damage. A frozen creature is affected by the petrified condition until the frozen effect ends.</description>
+            <description>You present your holy symbol and speak a prayer against undeath. Each undead that can see or hear you within 30 feet of you must make a Wisdom saving throw (save DC {{spellcasting:dc:cha}}). If the creature fails its saving throw, it is frozen for 1 minute or until it takes damage. A frozen creature is affected by the petrified condition until the frozen effect ends.</description>
         </sheet>
     </element>  
     

--- a/reddit/reddit-unearthed-arcana/dark-arts-players-companion/ranger-nightstalker.xml
+++ b/reddit/reddit-unearthed-arcana/dark-arts-players-companion/ranger-nightstalker.xml
@@ -3,7 +3,7 @@
     <info>
         <name>Nightstalker Ranger Archteype</name>
 		<author url="https://drive.google.com/file/d/1Kr3ZKYy3Me0ZFOhOQAmKBZlB9JUauhW5/view">Jonoman3000</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="ranger-nightstalker.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/dark-arts-players-companion/ranger-nightstalker.xml" />
         </update>
     </info>
@@ -80,7 +80,7 @@
             <p class="indent">As an action, you can expend a ranger spell slot to infuse the cat’s claws with poison and have it leap onto a target within 30 feet of it. That creature must succeed on a Constitution saving throw against your Ranger spell save DC or be poisoned until the end of your next turn and take 2d8 poison damage for a 1st level spell slot, plus 1d8 for each spell level higher than 1st.</p>
         </description>
         <sheet action="Action">
-            <description>Your cat can attack in place of one of your attacks to have it move up to 30 feet and attack a creature. Hits do 1d4 + {{wisdom:modifier}} slashing damage, and the next attack against the creature has advantage. You can expend a ranger spell slot to infuse the attack with poison. It can travel 30 feet to attack. Target must make a Constitution saving throw (save DC {{spellcasting:dc}}) or be poisoned and take 2d8 poison damage, plus 1d8 for each spell slot higher than 1st.</description>
+            <description>Your cat can attack in place of one of your attacks to have it move up to 30 feet and attack a creature. Hits do 1d4 + {{wisdom:modifier}} slashing damage, and the next attack against the creature has advantage. You can expend a ranger spell slot to infuse the attack with poison. It can travel 30 feet to attack. Target must make a Constitution saving throw (save DC {{spellcasting:dc:wis}}) or be poisoned and take 2d8 poison damage, plus 1d8 for each spell slot higher than 1st.</description>
         </sheet>
     </element>
     
@@ -91,7 +91,7 @@
             <p class="indent">As an action, you can expend a ranger spell slot to infuse the raven with lightning and have it travel along a line 5 feet wide and 30 feet long. Each creature in that line must succeed on a Dexterity saving throw or take 2d6 lightning damage for a 1st level spell slot, plus 1d6 for each spell level higher than 1st.</p>
         </description>
         <sheet action="Action">
-            <description>Your raven can attack in place of one of your attacks to have it move up to 30 feet and attack a creature. Hits do 1d10 + {{wisdom:modifier}} piercing damage. You can expend a ranger spell slot to infuse the raven with lightning. It can travel 30 feet to attack. Target must make a Constitution saving throw (save DC {{spellcasting:dc}}) or take 2d6 lightning damage, plus 1d6 for each spell slot higher than 1st.</description>
+            <description>Your raven can attack in place of one of your attacks to have it move up to 30 feet and attack a creature. Hits do 1d10 + {{wisdom:modifier}} piercing damage. You can expend a ranger spell slot to infuse the raven with lightning. It can travel 30 feet to attack. Target must make a Constitution saving throw (save DC {{spellcasting:dc:wis}}) or take 2d6 lightning damage, plus 1d6 for each spell slot higher than 1st.</description>
         </sheet>
     </element>
     

--- a/reddit/reddit-unearthed-arcana/dark-arts-players-companion/sorcerer-deathtouched.xml
+++ b/reddit/reddit-unearthed-arcana/dark-arts-players-companion/sorcerer-deathtouched.xml
@@ -3,7 +3,7 @@
     <info>
         <name>Deathtouched Sorcerous Origin</name>
 		<author url="https://drive.google.com/file/d/1Kr3ZKYy3Me0ZFOhOQAmKBZlB9JUauhW5/view">Jonoman3000</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="sorcerer-deathtouched.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/dark-arts-players-companion/sorcerer-deathtouched.xml" />
         </update>
     </info>
@@ -87,7 +87,7 @@
             <p class="indent">At the start of each of your turns, if the possessed creature has been damaged at least once since the end of your last turn it can repeat the saving throw, ending the effect on a success. You may also end the effect using your bonus action. A target is immune to Possession for 24 hours after succeeding on the saving throw.</p>
         </description>
         <sheet action="Action">
-            <description>you can spend 5 sorcery points to attempt to possess a creature of size large or smaller within 5 ft. of you. That creature must succeed on a Charisma saving throw (save DC {{spellcasting:dc}}) or be possessed for up to 1 hour.</description>
+            <description>you can spend 5 sorcery points to attempt to possess a creature of size large or smaller within 5 ft. of you. That creature must succeed on a Charisma saving throw (save DC {{spellcasting:dc:cha}}) or be possessed for up to 1 hour.</description>
         </sheet>
     </element>
     

--- a/reddit/reddit-unearthed-arcana/dark-arts-players-companion/wizard-school-of-reawakening.xml
+++ b/reddit/reddit-unearthed-arcana/dark-arts-players-companion/wizard-school-of-reawakening.xml
@@ -3,7 +3,7 @@
     <info>
         <name>School of Awakening</name>
 		<author url="https://drive.google.com/file/d/1Kr3ZKYy3Me0ZFOhOQAmKBZlB9JUauhW5/view">Jonoman3000</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="wizard-school-of-reawakening.xml" url="https://raw.githubusercontent.com/community-elements/elements-reddit/master/reddit/reddit-unearthed-arcana/dark-arts-players-companion/wizard-school-of-reawakening.xml" />
         </update>
     </info>
@@ -65,7 +65,7 @@
             <p class="indent">Each creature of your choice within a 10 ft radius of the exploding creature must make a Dexterity saving throw against your spell save DC. On a failed save, a creature takes 2d6 necrotic damage for every point of that creature’s CR. Creatures below CR 1 deal 1d6 necrotic damage. On a successful save, a creature takes half damage.</p>
         </description>
         <sheet>
-            <description>When you reawakened creature is reduced to 0 hit points, it explodes. Each creature of your choice within a 10 ft radius must make a Dexterity saving throw (save DC {{spellcasting:dc}}). On a failed save, a creature takes 2d6 necrotic damage for each CR. Creatures below CR 1 deal 1d6 damage. Half damage on a successful save.</description>
+            <description>When you reawakened creature is reduced to 0 hit points, it explodes. Each creature of your choice within a 10 ft radius must make a Dexterity saving throw (save DC {{spellcasting:dc:int}}). On a failed save, a creature takes 2d6 necrotic damage for each CR. Creatures below CR 1 deal 1d6 damage. Half damage on a successful save.</description>
         </sheet>
     </element>
     


### PR DESCRIPTION
This fixes the display of the save DC for spellcasting DC-based features in All the Lights in the Sky are Stars and the Dark Art's Players Companion subclasses.
`{{spellcasting:dc}}` has been updated to `{{spellcasting:dc:int}}`, `{{spellcasting:dc:wis}}`, or `{{spellcasting:dc:cha}}` as appropriate for the subclass.
Version numbers have been updated on files that have been fixed.